### PR TITLE
update version to 6.6.2.3

### DIFF
--- a/linglong.yaml
+++ b/linglong.yaml
@@ -4,11 +4,10 @@ package:
   id: org.deepin.browser
   kind: app
   name: deepin-browser
-  version: 6.6.1.0
+  version: 6.6.2.0
   description: browser for deepin os.
 
 base: main:org.deepin.base/23.1.0
-runtime: main:org.deepin.runtime.dtk/23.2.0
 
 command:
   - "browser"
@@ -28,8 +27,8 @@ build: |
   sed -i 's/\/usr\/bin\/browser/browser/' $PREFIX/share/applications/org.deepin.browser.desktop
 sources:
   - kind: file
-    url: https://aptly.uniontech.com/pkg/nonfree-eagle-1070/release-candidate/44CQ56S-5Yy654mI44CR44CQZGVlcGluX1YyM19SZWxlYXNl44CR44CQ6ZuG5oiQ5rWL6K-V44CR44CQ5rWP6KeI5Zmo44CRMjAyNC0wOC0wNyAxMzo1NToxNw/pool/non-free/o/org.deepin.browser/org.deepin.browser_6.5.3-1_amd64.deb
-    digest: 13d70e7821bbaf62bfa74a8a58f7bc02e7be375e66f90a3e48e1ce02ec0578c4
+    url: https://minio.cicd.getdeepin.org/share/org.deepin.browser_6.6.2_amd64.deb
+    digest: c8a69152588a77a6917786fb075d50584cfde1ed9dc2f1337406c6690215e278
   # linglong:gen_deb_source sources amd64 https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2 beige main community
   # linglong:gen_deb_source install libasound2 (>= 1.0.16), libatk-bridge2.0-0 (>= 2.5.3), libatk1.0-0 (>= 2.2.0), libatomic1 (>= 4.8), libatspi2.0-0 (>= 2.9.90), libc6 (>= 2.28), libcairo2 (>= 1.6.0), libcups2 (>= 1.7.0), libdbus-1-3 (>= 1.9.14), libdrm2 (>= 2.4.38), libexpat1 (>= 2.0.1), libfontconfig1 (>= 2.12.6), libfreetype6 (>= 2.11.0), libgbm1 (>= 17.1.0~rc2), libgcc1 (>= 1:4.0), libgdk-pixbuf2.0-0 (>= 2.22.0), libgl1, libglib2.0-0 (>= 2.39.4), libgtk2.0-0 (>= 2.24.0), libnspr4 (>= 2:4.9-2~), libnss3 (>= 2:3.38), libpango-1.0-0 (>= 1.14.0), libsnappy1v5, libstdc++6 (>= 7), libx11-6 (>= 2:1.4.99.1), libxcb1 (>= 1.9.2), libxcomposite1 (>= 1:0.3-1), libxdamage1 (>= 1:1.1), libxext6, libxfixes3, libxkbcommon0 (>= 0.5.0), libxrandr2, libxshmfence1, x11-utils, xdg-utils
   # linglong:gen_deb_source install libsnappy1v5, procps

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -4,7 +4,7 @@ package:
   id: org.deepin.browser
   kind: app
   name: deepin-browser
-  version: 6.6.2.0
+  version: 6.6.2.1
   description: browser for deepin os.
 
 base: main:org.deepin.base/23.1.0
@@ -27,8 +27,8 @@ build: |
   sed -i 's/\/usr\/bin\/browser/browser/' $PREFIX/share/applications/org.deepin.browser.desktop
 sources:
   - kind: file
-    url: https://minio.cicd.getdeepin.org/share/org.deepin.browser_6.6.2_amd64.deb
-    digest: c8a69152588a77a6917786fb075d50584cfde1ed9dc2f1337406c6690215e278
+    url: https://minio.cicd.getdeepin.org/share/org.deepin.browser_6.6.2.1_amd64.deb
+    digest: 794b081086f50f3711a2450ba2859ebea18783f8daaa89d128f31a3b8fe33408
   # linglong:gen_deb_source sources amd64 https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2 beige main community
   # linglong:gen_deb_source install libasound2 (>= 1.0.16), libatk-bridge2.0-0 (>= 2.5.3), libatk1.0-0 (>= 2.2.0), libatomic1 (>= 4.8), libatspi2.0-0 (>= 2.9.90), libc6 (>= 2.28), libcairo2 (>= 1.6.0), libcups2 (>= 1.7.0), libdbus-1-3 (>= 1.9.14), libdrm2 (>= 2.4.38), libexpat1 (>= 2.0.1), libfontconfig1 (>= 2.12.6), libfreetype6 (>= 2.11.0), libgbm1 (>= 17.1.0~rc2), libgcc1 (>= 1:4.0), libgdk-pixbuf2.0-0 (>= 2.22.0), libgl1, libglib2.0-0 (>= 2.39.4), libgtk2.0-0 (>= 2.24.0), libnspr4 (>= 2:4.9-2~), libnss3 (>= 2:3.38), libpango-1.0-0 (>= 1.14.0), libsnappy1v5, libstdc++6 (>= 7), libx11-6 (>= 2:1.4.99.1), libxcb1 (>= 1.9.2), libxcomposite1 (>= 1:0.3-1), libxdamage1 (>= 1:1.1), libxext6, libxfixes3, libxkbcommon0 (>= 0.5.0), libxrandr2, libxshmfence1, x11-utils, xdg-utils
   # linglong:gen_deb_source install libsnappy1v5, procps

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -28,7 +28,7 @@ build: |
 sources:
   - kind: file
     url: https://minio.cicd.getdeepin.org/share/org.deepin.browser_6.6.2.2_amd64.deb
-    digest: 794b081086f50f3711a2450ba2859ebea18783f8daaa89d128f31a3b8fe33408
+    digest: a774ab0d064fa661a71e7626f8da40b5bac15f9a6b606790a22270318950c8a8
   # linglong:gen_deb_source sources amd64 https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2 beige main community
   # linglong:gen_deb_source install libasound2 (>= 1.0.16), libatk-bridge2.0-0 (>= 2.5.3), libatk1.0-0 (>= 2.2.0), libatomic1 (>= 4.8), libatspi2.0-0 (>= 2.9.90), libc6 (>= 2.28), libcairo2 (>= 1.6.0), libcups2 (>= 1.7.0), libdbus-1-3 (>= 1.9.14), libdrm2 (>= 2.4.38), libexpat1 (>= 2.0.1), libfontconfig1 (>= 2.12.6), libfreetype6 (>= 2.11.0), libgbm1 (>= 17.1.0~rc2), libgcc1 (>= 1:4.0), libgdk-pixbuf2.0-0 (>= 2.22.0), libgl1, libglib2.0-0 (>= 2.39.4), libgtk2.0-0 (>= 2.24.0), libnspr4 (>= 2:4.9-2~), libnss3 (>= 2:3.38), libpango-1.0-0 (>= 1.14.0), libsnappy1v5, libstdc++6 (>= 7), libx11-6 (>= 2:1.4.99.1), libxcb1 (>= 1.9.2), libxcomposite1 (>= 1:0.3-1), libxdamage1 (>= 1:1.1), libxext6, libxfixes3, libxkbcommon0 (>= 0.5.0), libxrandr2, libxshmfence1, x11-utils, xdg-utils
   # linglong:gen_deb_source install libsnappy1v5, procps

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -4,7 +4,7 @@ package:
   id: org.deepin.browser
   kind: app
   name: deepin-browser
-  version: 6.6.2.2
+  version: 6.6.2.3
   description: browser for deepin os.
 
 base: main:org.deepin.base/23.1.0
@@ -27,8 +27,8 @@ build: |
   sed -i 's/\/usr\/bin\/browser/browser/' $PREFIX/share/applications/org.deepin.browser.desktop
 sources:
   - kind: file
-    url: https://minio.cicd.getdeepin.org/share/org.deepin.browser_6.6.2.2_amd64.deb
-    digest: a774ab0d064fa661a71e7626f8da40b5bac15f9a6b606790a22270318950c8a8
+    url: https://minio.cicd.getdeepin.org/share/org.deepin.browser_6.6.2.3_amd64.deb
+    digest: d342f65f43381c0c6b3e89ed3bdb6213ce963867491af63d894a9c84f5da743c
   # linglong:gen_deb_source sources amd64 https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2 beige main community
   # linglong:gen_deb_source install libasound2 (>= 1.0.16), libatk-bridge2.0-0 (>= 2.5.3), libatk1.0-0 (>= 2.2.0), libatomic1 (>= 4.8), libatspi2.0-0 (>= 2.9.90), libc6 (>= 2.28), libcairo2 (>= 1.6.0), libcups2 (>= 1.7.0), libdbus-1-3 (>= 1.9.14), libdrm2 (>= 2.4.38), libexpat1 (>= 2.0.1), libfontconfig1 (>= 2.12.6), libfreetype6 (>= 2.11.0), libgbm1 (>= 17.1.0~rc2), libgcc1 (>= 1:4.0), libgdk-pixbuf2.0-0 (>= 2.22.0), libgl1, libglib2.0-0 (>= 2.39.4), libgtk2.0-0 (>= 2.24.0), libnspr4 (>= 2:4.9-2~), libnss3 (>= 2:3.38), libpango-1.0-0 (>= 1.14.0), libsnappy1v5, libstdc++6 (>= 7), libx11-6 (>= 2:1.4.99.1), libxcb1 (>= 1.9.2), libxcomposite1 (>= 1:0.3-1), libxdamage1 (>= 1:1.1), libxext6, libxfixes3, libxkbcommon0 (>= 0.5.0), libxrandr2, libxshmfence1, x11-utils, xdg-utils
   # linglong:gen_deb_source install libsnappy1v5, procps

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -4,7 +4,7 @@ package:
   id: org.deepin.browser
   kind: app
   name: deepin-browser
-  version: 6.6.2.1
+  version: 6.6.2.2
   description: browser for deepin os.
 
 base: main:org.deepin.base/23.1.0
@@ -27,7 +27,7 @@ build: |
   sed -i 's/\/usr\/bin\/browser/browser/' $PREFIX/share/applications/org.deepin.browser.desktop
 sources:
   - kind: file
-    url: https://minio.cicd.getdeepin.org/share/org.deepin.browser_6.6.2.1_amd64.deb
+    url: https://minio.cicd.getdeepin.org/share/org.deepin.browser_6.6.2.2_amd64.deb
     digest: 794b081086f50f3711a2450ba2859ebea18783f8daaa89d128f31a3b8fe33408
   # linglong:gen_deb_source sources amd64 https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2 beige main community
   # linglong:gen_deb_source install libasound2 (>= 1.0.16), libatk-bridge2.0-0 (>= 2.5.3), libatk1.0-0 (>= 2.2.0), libatomic1 (>= 4.8), libatspi2.0-0 (>= 2.9.90), libc6 (>= 2.28), libcairo2 (>= 1.6.0), libcups2 (>= 1.7.0), libdbus-1-3 (>= 1.9.14), libdrm2 (>= 2.4.38), libexpat1 (>= 2.0.1), libfontconfig1 (>= 2.12.6), libfreetype6 (>= 2.11.0), libgbm1 (>= 17.1.0~rc2), libgcc1 (>= 1:4.0), libgdk-pixbuf2.0-0 (>= 2.22.0), libgl1, libglib2.0-0 (>= 2.39.4), libgtk2.0-0 (>= 2.24.0), libnspr4 (>= 2:4.9-2~), libnss3 (>= 2:3.38), libpango-1.0-0 (>= 1.14.0), libsnappy1v5, libstdc++6 (>= 7), libx11-6 (>= 2:1.4.99.1), libxcb1 (>= 1.9.2), libxcomposite1 (>= 1:0.3-1), libxdamage1 (>= 1:1.1), libxext6, libxfixes3, libxkbcommon0 (>= 0.5.0), libxrandr2, libxshmfence1, x11-utils, xdg-utils

--- a/org.deepin.browser.install
+++ b/org.deepin.browser.install
@@ -77,9 +77,8 @@
 /opt/apps/org.deepin.browser/files/share/dsg/configs/org.deepin.browser
 /opt/apps/org.deepin.browser/files/share/dsg/configs/org.deepin.browser/org.deepin.browser.json
 /opt/apps/org.deepin.browser/files/share/browser
-/opt/apps/org.deepin.browser/files/share/browser/swiftshader
-/opt/apps/org.deepin.browser/files/share/browser/swiftshader/libGLESv2.so
-/opt/apps/org.deepin.browser/files/share/browser/swiftshader/libEGL.so
+/opt/apps/org.deepin.browser/files/share/browser/libGLESv2.so
+/opt/apps/org.deepin.browser/files/share/browser/libEGL.so
 /opt/apps/org.deepin.browser/files/share/browser/minidump_stackwalk
 /opt/apps/org.deepin.browser/files/share/browser/browser-sandbox
 /opt/apps/org.deepin.browser/files/share/browser/.pki
@@ -87,7 +86,7 @@
 /opt/apps/org.deepin.browser/files/share/browser/.pki/uos_nssdb/cert9.db
 /opt/apps/org.deepin.browser/files/share/browser/.pki/uos_nssdb/key4.db
 /opt/apps/org.deepin.browser/files/share/browser/.pki/uos_nssdb/pkcs11.txt
-/opt/apps/org.deepin.browser/files/share/browser/crashpad_handler
+/opt/apps/org.deepin.browser/files/share/browser/chrome_crashpad_handler
 /opt/apps/org.deepin.browser/files/share/browser/snapshot_blob.bin
 /opt/apps/org.deepin.browser/files/share/browser/initial_bookmarks.html
 /opt/apps/org.deepin.browser/files/share/browser/master_preferences


### PR DESCRIPTION
修复问题：
* [【deepin 25】【集成测试】【浏览器】因deepin 25 现阶段的云同步未完成，浏览器的同步功能需要屏蔽](https://pms.uniontech.com/bug-view-303037.html)
* [【deepin 25】【集成测试】【浏览器】英文环境下，浏览器实际添加书签成功，但没有在书签栏显示](https://pms.uniontech.com/bug-view-303053.html)