### PR TITLE
feat: update version to 6.6.2.4

### DIFF
--- a/linglong.yaml
+++ b/linglong.yaml
@@ -4,7 +4,7 @@ package:
   id: org.deepin.browser
   kind: app
   name: deepin-browser
-  version: 6.6.2.3
+  version: 6.6.2.4
   description: browser for deepin os.
 
 base: main:org.deepin.base/23.1.0
@@ -27,584 +27,169 @@ build: |
   sed -i 's/\/usr\/bin\/browser/browser/' $PREFIX/share/applications/org.deepin.browser.desktop
 sources:
   - kind: file
-    url: https://minio.cicd.getdeepin.org/share/org.deepin.browser_6.6.2.3_amd64.deb
-    digest: d342f65f43381c0c6b3e89ed3bdb6213ce963867491af63d894a9c84f5da743c
+    url: https://minio.cicd.getdeepin.org/share/org.deepin.browser_6.6.2.4_amd64.deb
+    digest: bd775a13bc434664cbc6475d685b18fe913ed7a893d0dacf07172f4b3fb198b2
   # linglong:gen_deb_source sources amd64 https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2 beige main community
   # linglong:gen_deb_source install libasound2 (>= 1.0.16), libatk-bridge2.0-0 (>= 2.5.3), libatk1.0-0 (>= 2.2.0), libatomic1 (>= 4.8), libatspi2.0-0 (>= 2.9.90), libc6 (>= 2.28), libcairo2 (>= 1.6.0), libcups2 (>= 1.7.0), libdbus-1-3 (>= 1.9.14), libdrm2 (>= 2.4.38), libexpat1 (>= 2.0.1), libfontconfig1 (>= 2.12.6), libfreetype6 (>= 2.11.0), libgbm1 (>= 17.1.0~rc2), libgcc1 (>= 1:4.0), libgdk-pixbuf2.0-0 (>= 2.22.0), libgl1, libglib2.0-0 (>= 2.39.4), libgtk2.0-0 (>= 2.24.0), libnspr4 (>= 2:4.9-2~), libnss3 (>= 2:3.38), libpango-1.0-0 (>= 1.14.0), libsnappy1v5, libstdc++6 (>= 7), libx11-6 (>= 2:1.4.99.1), libxcb1 (>= 1.9.2), libxcomposite1 (>= 1:0.3-1), libxdamage1 (>= 1:1.1), libxext6, libxfixes3, libxkbcommon0 (>= 0.5.0), libxrandr2, libxshmfence1, x11-utils, xdg-utils
   # linglong:gen_deb_source install libsnappy1v5, procps
+
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/a/adwaita-icon-theme/adwaita-icon-theme_45.0-2_all.deb
-    digest: 709761989d315d674f0e14c837afdd256ef58c941e49889307eb41f969e69069
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/a/at-spi2-core/at-spi2-common_2.50.0-1_all.deb
-    digest: 5289ad162167a611940e8f169ce6a1e6974bbe14f77a66ee890c137196fc654a
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/d/debconf/debconf_1.5.79-deepin_all.deb
-    digest: ded6aaa7927ae27337ceb23d49391b4c7ec460a00ba692020e8f4e28388f345f
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/d/dpkg/dpkg_1.22.6deepin3_amd64.deb
-    digest: f9c758ed0204b1fe515c70b6419f80fdeb4773ac3f498a79ea1e6a6e6971157f
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/f/fontconfig/fontconfig_2.14.2-6_amd64.deb
-    digest: 1018476410ec372cb5f96e3a4d4b4d51781c613212eb71f91bcc939c2de0e8f2
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/f/fontconfig/fontconfig-config_2.14.2-6_amd64.deb
-    digest: ca239a17d79f439fc02525b3b3c83d6cdf0be1a90c6aa6ec6c19b2b92b0d6586
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
-    digest: afbaf120869a08aa7dd14da9ad014de48a751aa4330534b531410bb86c411b55
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/f/fonts-dejavu/fonts-dejavu-core_2.37-deepin_all.deb
-    digest: 5982963d05dbf4efa009c3ab6db3576a03f680199d75d7d5edda89c55def912c
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
-    digest: c66666da94b9a0477351ee9d6d7a247a0a3c842e428da770991b45f03be2ee72
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
-    digest: 79b23c3945d4628463672a804a0e81bc4c262ef87cb6316afb40167a50bc3145
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
-    digest: 9285213fd8d6515bc6c1be5b810bf39918a668a17024a9fd3541879ce7fb5344
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/f/fonts-noto/fonts-noto-core_20201225-deepin_all.deb
-    digest: fa09d95f516c498d55e516d549b8ee41d9a7b6f17cdf0bb4b43744d672ce1366
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
-    digest: f66d6f798c4b99d8490558cc8209c069b0fe5577c11378c0e01f9e87ddf10824
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/f/fonts-urw-base35/fonts-urw-base35_20200910-7_all.deb
-    digest: 4800c0b08fbeac0335f1e23df2d41528a242383324c256ebece00c8f438eefbd
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/g/gcc-13/gcc-13-base_13.2.0-3deepin2_amd64.deb
-    digest: 934755185f12fa095cdb596552ed9c59151796f5fdc418f0c8342d0d7f338ee9
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/g/gnome-icon-theme/gnome-icon-theme_3.12.0-5_all.deb
-    digest: 3e2891535d7113537c43f5a292acaa325b743c2f80b044924cb45eade9a955fc
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/g/gtk+3.0/gtk-update-icon-cache_3.24.41-1deepin1_amd64.deb
-    digest: 5a9a19405f255726761ae5ca713064be5a9142462b4f4cd6b0bc68a23207b686
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/h/hicolor-icon-theme/hicolor-icon-theme_0.17-2_all.deb
-    digest: 5ef21bfc6380fee893422ce212f7f0d4bc9c2219d5167680cbfd7831ec28a9a5
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/i/init-system-helpers/init-system-helpers_1.66_all.deb
-    digest: 60bb52a4118d514e4d480707329a798ae21d135a96ddb9811d7e6bd0e7f2101f
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/a/acl/libacl1_2.3.1-1_amd64.deb
-    digest: f06e936eb913b8e9271c17e6d8b94d9e4f0aa558d7debdc324c9484908ee8dc8
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/a/alsa-lib/libasound2_1.2.8-1_amd64.deb
-    digest: 9369d835efeb62d2e639a45a2cc2ed5110ad259bbf0a3be12ea98475c85beab6
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/a/alsa-lib/libasound2-data_1.2.8-1_all.deb
-    digest: cc8b0202a4e88d3c744fc9d4719a61b945b3b02759fa1af6bd55da6432119b2e
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/a/at-spi2-core/libatk-bridge2.0-0_2.50.0-1_amd64.deb
-    digest: 251c33003337b63840a5eaa4e24bff47c179dedea3fc8b153e752ae2d4823484
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/a/at-spi2-core/libatk1.0-0_2.50.0-1_amd64.deb
-    digest: da6c703d5afc663d8d3716e3134b76bb47cecb54f75f0f6f846cbd47fd822613
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/g/gcc-13/libatomic1_13.2.0-3deepin2_amd64.deb
-    digest: 3f9abfc6f99730ebcb3f12da87f93c47db9e26f35d19d9a65a9c2d38bde97bf1
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/a/at-spi2-core/libatspi2.0-0_2.50.0-1_amd64.deb
+    url: https://community-packages.deepin.com/beige/pool/main/a/at-spi2-core/libatspi2.0-0_2.50.0-1_amd64.deb
     digest: 119b3d4e3a1d9aca00246c2cdae2dd5ab803b0fbc08d3ba2a71ecebf987380d0
+
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/a/avahi/libavahi-client3_0.8-5_amd64.deb
-    digest: 28bdf7a8c0529f6397921fe59358e8d94cf3d3f1e498f09e9b4035254ee15baf
+    url: https://community-packages.deepin.com/beige/pool/main/libe/libevent/libevent-2.1-7_2.1.12-stable-8deepin1_amd64.deb
+    digest: d506bfdb600ce068028e0b7cc9825f0f5b56d91781c6ee0292d3faa66fb805f3
+
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/a/avahi/libavahi-common-data_0.8-5_amd64.deb
-    digest: 5fdc5ef24ff229630b683db663cb26e108aa719fd288b808c4607c680de52c75
+    url: https://community-packages.deepin.com/beige/pool/main/c/cups/libcups2_2.4.2-5deepin1_amd64.deb
+    digest: e48aff0e7bd13a310516cfc5dcbdb68d789ef8e4c949afe7e638fb402a90f150
+
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/a/avahi/libavahi-common3_0.8-5_amd64.deb
-    digest: a966db72e688d76b06a665dfe894c66faae8d2033cf5dd8776bf56f41912035f
+    url: https://community-packages.deepin.com/beige/pool/main/p/pulseaudio/libpulse0_16.1+dfsg1-5.1deepin1_amd64.deb
+    digest: ad40b445b798ba098f7191b90a5e949f091b039bcb5961d271fc9715f3f2053d
+
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/u/util-linux/libblkid1_2.39.3-6deepin1_amd64.deb
-    digest: 1c0d4c5b5efec4a282652df9793083bdd4e7fc0ed634dc76f3bf6ee700dfa8c4
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/b/brotli/libbrotli1_1.1.0-1_amd64.deb
-    digest: 36d35c961b011d90846409e88990ea9ab004b55c210cf50b7b9a01c6acc15803
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libb/libbsd/libbsd0_0.11.7-4_amd64.deb
-    digest: 40e8755d2d6de7ee5c90483c74d586c6270f088eaf630acdc32bc848c09cedfe
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/b/bzip2/libbz2-1.0_1.0.8-deepin_amd64.deb
-    digest: 7f5ce12761d6099a94205e330066656c96e759a6ab393730a6a91a1aa817beff
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/g/glibc/libc6_2.38-6deepin4_amd64.deb
-    digest: 528cd175b88a701953e4271e0528afbc1f8e815b9710e4bf5d48d35a2723f92b
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/c/cairo/libcairo-gobject2_1.18.0-1_amd64.deb
-    digest: 58dc2ae2cd25e9ba5e45c571fd4c0fe77450cd98128dc28c2183b7434aa4d914
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/c/cairo/libcairo2_1.18.0-1_amd64.deb
-    digest: cbf026997021678131d706318414a498b8054291185be3fa095fe8ea9fe162fc
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libc/libcap2/libcap2_2.44-1_amd64.deb
-    digest: 80964e76de54cf25286f16d15361610bfdda4c552da2c36e353428596bd4441a
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/e/e2fsprogs/libcom-err2_1.47.0-2_amd64.deb
-    digest: 81c9a2cd03a925f323e8021855825a535a259867652b5d35006ef468cb17417f
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxcrypt/libcrypt1_4.4.36-2_amd64.deb
-    digest: 3ebae5a5f27eff3c2b9598ba323b4b556d6cec915a78200e305fb6ecde3972cd
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/c/cups/libcups2_2.4.2-5_amd64.deb
-    digest: 11fbf5b0d748cf38a9a6d05a308433c93fe340c8bc6f57405a3630abcb53f802
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libd/libdatrie/libdatrie1_0.2.13-2_amd64.deb
-    digest: 07aa08beb07e987772c31ef3865ef65b8ea37069c7c840c8a2a56c6d0019df07
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8_amd64.deb
-    digest: 289a3fce1a5b476bd2269ae66ac701835d1228614965cbda4134ee95f5a5deba
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/d/dbus/libdbus-1-3_1.14.10-3_amd64.deb
-    digest: 1dff3a63259f14e7de7c4502e7083f7077b30a274f09d195176d566406b1b827
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libd/libdeflate/libdeflate0_1.18-1_amd64.deb
-    digest: 1b411007d982c5f2f2a6d1e2d0af7a85cbc274770e533fbd895fc54956a995ba
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libd/libdrm/libdrm-amdgpu1_2.4.119-1deepin1_amd64.deb
-    digest: da1e363354894ba5491dd60958ac2bf440ddc5218399632cdf94006e15f97e3a
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libd/libdrm/libdrm-common_2.4.119-1deepin1_all.deb
-    digest: c32b39f2496833a38f1c5c0c61f9f08d3c5b88da018a7b923367831d488a7061
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libd/libdrm/libdrm-intel1_2.4.119-1deepin1_amd64.deb
-    digest: 60ba3eaef17b90b5b8b8f82222e797a8e430a181ca7ba78846e370faa75a32ac
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libd/libdrm/libdrm-nouveau2_2.4.119-1deepin1_amd64.deb
-    digest: f4bf6f5f65106f9d3c82067da31c4490f5090a837eeb0e493b7919ec2a4b599f
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libd/libdrm/libdrm-radeon1_2.4.119-1deepin1_amd64.deb
-    digest: d1769d0c64768d5b3eaeb8dd8d6d725d35a7c0e6ed007b849ef33c5f6aaa752b
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libd/libdrm/libdrm2_2.4.119-1deepin1_amd64.deb
-    digest: 98bcb40fa91adcc6ffa6dbd2af302a58afac9398164d8d79446284eef7bc4ca4
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libe/libedit/libedit2_3.1-20230828-1_amd64.deb
-    digest: 72d015604676696e4e10e238f4795fbdc3d7c0e241147d55c9782ea8baf9a03c
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/e/elfutils/libelf1_0.188-2.1deepin1_amd64.deb
-    digest: e65d005580124013710ebc5b4b7777c1cef9ff4730a2e07e12f5e179a6aaed87
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/e/expat/libexpat1_2.5.0-2_amd64.deb
-    digest: 5be8be254b82a58e77549b1784520f1f7ebb395b57982f87524533e1f061f75a
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libf/libffi/libffi8_3.4.6-1_amd64.deb
-    digest: daa2aeb5a23c7dea09b2f16b94d15fa6f015ad5ff8c3db15bd0ab890fc920dd2
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libf/libfile-find-rule-perl/libfile-find-rule-perl_0.34-1_all.deb
-    digest: 8ebc94473bf3381e34408415da523e390c2fb3be418f3c298deb6bc82373ded5
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/f/fontconfig/libfontconfig1_2.14.2-6_amd64.deb
-    digest: c4c5fa416637a08cf925dd4ec0115631b69e4f2f5f46f2094f3239167f781085
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libf/libfontenc/libfontenc1_1.1.4-1_amd64.deb
-    digest: 758a94a3acf10d671cc056981255d2bca91e42d74e46edb27f3c89b9c5d5d3cf
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/f/freetype/libfreetype6_2.13.2+dfsg-1deepin1_amd64.deb
-    digest: 362fcb4c7c381338fd78bfa018b17b25f00596afb9c7d99c28b075944b20eb2b
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/f/fribidi/libfribidi0_1.0.8-2_amd64.deb
-    digest: cb0bd9ae5b3c84a26fa8de5a614b557caa3e312fb93b35c46e551c8135275e90
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/m/mesa/libgbm1_24.0.1-1deepin3_amd64.deb
-    digest: 7c865d2d2a271170fe22be2163dfeaa83130d3a5be53283c90fb296374d2e131
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/g/gcc-13/libgcc-s1_13.2.0-3deepin2_amd64.deb
-    digest: ff2d64158ae82f27ff107a3e2cc42e4b4986f048cadd4ce6cd97130cc3deacea
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libg/libgcrypt20/libgcrypt20_1.10.3-2_amd64.deb
-    digest: f377a741b54094b2b71a461878bf012c8d602d9af146be9826ce058767e396d5
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/g/gdbm/libgdbm-compat4_1.22-1_amd64.deb
-    digest: 35bdaf12b3222875708f4f3967f4517897062a05730f38893695d6344e4f496e
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/g/gdbm/libgdbm6_1.22-1_amd64.deb
-    digest: af88f48a9978a03543cb1bb5170ef936fb80595c8621d73137ba47bfef0de0d3
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/g/gdk-pixbuf/libgdk-pixbuf-2.0-0_2.42.10+dfsg-3_amd64.deb
-    digest: ae9e961d452cbbcb9b8be26835441805f05888a1840799162c2c1ccff924f9a9
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/g/gdk-pixbuf-xlib/libgdk-pixbuf-xlib-2.0-0_2.40.2-2_amd64.deb
-    digest: 25aa60590924b9c61c8d71e7a6caf67ae63ad4b593a66e2a27fd14efee3a072c
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/g/gdk-pixbuf-xlib/libgdk-pixbuf2.0-0_2.40.2-2_amd64.deb
-    digest: d4770a3df6d4c3f3f939641e5b986833a063dcf29c48169a96dc18d6aceca824
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/g/gdk-pixbuf/libgdk-pixbuf2.0-common_2.42.10+dfsg-3_all.deb
-    digest: bcf7a388b33a76d765b3db4dc10fc0a946086bc7409228898ffbcc522e9dffc9
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libg/libglvnd/libgl1_1.7.0-1_amd64.deb
-    digest: 1889b6be38cb7319734d330c232b64aff31845745c74732bf824fe39bcbfdb6e
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/m/mesa/libgl1-mesa-dri_24.0.1-1deepin3_amd64.deb
-    digest: a43c15630c4a6faeed06d6307cbdee58ddfadb3a1f95782a19b43afbb9d3e917
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/m/mesa/libglapi-mesa_24.0.1-1deepin3_amd64.deb
-    digest: 4794d4bbac9b7bb29f8ae0c744c9ff47e57b991f804c8be7473749418e4aba06
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/g/glib2.0/libglib2.0-0_2.80.1-1deepin1_amd64.deb
-    digest: 33857078b63370d9edfbceec5a4f8d159db6f75da9f486dd12c97711598f43de
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libg/libglvnd/libglvnd0_1.7.0-1_amd64.deb
-    digest: dbc3b9a38a5527c8a02d8edf0f87779993272d61d9b24c3209df69d1ebf3e540
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/m/mesa/libglx-mesa0_24.0.1-1deepin3_amd64.deb
-    digest: 9f0cb9ef7c75fa7a6eb8e3f107647aaea6ad8a6cb8c49f274b752a740caf614d
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libg/libglvnd/libglx0_1.7.0-1_amd64.deb
-    digest: 30197452c9ee62b7a7063d1a9f208ffae0eefec86800340a104a884543d133d0
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/g/gmp/libgmp10_6.3.0+dfsg-2_amd64.deb
-    digest: f6f7232622006411e226a59b2e1bb11da8da62dec41d618b406c4378f467e7e4
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/g/gnutls28/libgnutls30_3.7.9-2_amd64.deb
-    digest: d56ddf6802b16bc9c2ba21d8c5d6312e0620c9b96dfc11f8345d42c8233e9e74
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libg/libgpg-error/libgpg-error0_1.47-3_amd64.deb
-    digest: c7c00dbad22e7c549a25c147e3d471fae76d0c22d479c0de61aac4cf60e97f36
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/g/graphite2/libgraphite2-3_1.3.14-1deepin1_amd64.deb
-    digest: 3dd8bace90f960c424d8b64664c61d3cc2974ff10b346f896381010d866f1e11
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/k/krb5/libgssapi-krb5-2_1.20.1-5_amd64.deb
-    digest: dfa250b0e4ecb5b3c359f49161b460b0139c38b1592b6d6538395855f6c952f1
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/g/gtk+2.0/libgtk2.0-0_2.24.33-4+deepin_amd64.deb
-    digest: ea5e91a857b828842d0a3c83d3fda4d80be6ec6a423486d0071420a116fb7b3f
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/g/gtk+2.0/libgtk2.0-common_2.24.33-4+deepin_all.deb
-    digest: f7e956f9682e526826f2f27a6fc934ffe0fa280667e50b353f420bb85b47655a
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/h/harfbuzz/libharfbuzz0b_8.0.1-1+rb1_amd64.deb
-    digest: 29f8f51877821f22adc742cab010c0f627ff4db8ffb03a1479441c5f2061f9e3
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/n/nettle/libhogweed6_3.7.3-1_amd64.deb
-    digest: 0557f0e34a15444b6792c2726b5d1eb48f9ea8cd42bc7f4d697081e804ced558
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libi/libice/libice6_1.0.10-1_amd64.deb
-    digest: 03da9ec604f5bd9ba6526c4e6cf90c5b4266818b2c9a34110d74c42b9be87646
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/i/icu/libicu74_74.2-1_amd64.deb
-    digest: ad3f769fb52e996fad6d8dd369ab7a09f558b221ddc7647164ab8cc0bd8fa245
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libi/libidn2/libidn2-0_2.3.2-2_amd64.deb
-    digest: 0ac47209fe66a5906497d6fb1c76a2addaa8daa2becaa434b17d32b98dd057cc
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/j/jbigkit/libjbig0_2.1-3.1-deepin1_amd64.deb
-    digest: 98eb75afc9dd66ec83f782a46aad59b0add9aad5ac521e91e35d606bb6313147
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.1.5-2_amd64.deb
-    digest: 664abd1a931622f6d14cced9ea87f3b4f201adf9616e6ef2daf1b044903f699f
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/k/krb5/libk5crypto3_1.20.1-5_amd64.deb
-    digest: 203bda60f112a6eb51bfb431c1c9287ff1dbfd4f8bacb931b8ab5aacf52ed4e3
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/k/keyutils/libkeyutils1_1.6.1-3_amd64.deb
-    digest: 0c6c254e3c601388fde14c7e1816d00d9b810d61d22bb7fc11ffc0b133f43a04
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/k/krb5/libkrb5-3_1.20.1-5_amd64.deb
-    digest: ae4f1183b97f1f376f8caac13b739865aba4b4b77bcfec8d9dd86c85e6977411
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/k/krb5/libkrb5support0_1.20.1-5_amd64.deb
-    digest: bdc056efb59abe666c17a028924d456a5660c45b68259d2525b9a0d08a8524a2
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/l/lerc/liblerc4_4.0.0+ds-3_amd64.deb
-    digest: 4024f109044643693dad079fce71b942ffba3bf3ec994d523130c33e776ea06e
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/l/llvm-toolchain-17/libllvm17_17.0.6-5deepin1_amd64.deb
-    digest: d4335b638011d8b79c5ec4b6bd2cd6ad00d84a87b1610b452de35f5e09a83def
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/l/lz4/liblz4-1_1.9.3-deepin_amd64.deb
-    digest: 9808e49cf41c4a38f0ff4f4de7080ae392682f3cea166abc079a26625c8233aa
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/x/xz-utils/liblzma5_5.4.5-0.3_amd64.deb
-    digest: e8051c2b44fa1cc020c12ef45f4918c1dd7595532af89df0c583b4b3f333fa56
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libm/libmd/libmd0_1.0.4-1_amd64.deb
-    digest: 755e2a59d76415999f46b0c307ade64df3788013286e902e2531e07ff58ca781
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/u/util-linux/libmount1_2.39.3-6deepin1_amd64.deb
-    digest: a6c22f3b3c30d72424a05ee1c8874674d4e69b5dd703aa7b8936c7c21ab8c009
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/n/ncurses/libncursesw6_6.4-4_amd64.deb
-    digest: 9993f7cfcc8cf37e6474d7b570faf1d5a19187af8a820f38cd5315461c765f2f
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/n/nettle/libnettle8_3.7.3-1_amd64.deb
-    digest: d19dd4ebabccc00232223b414732c26b63d4ee67f4147ad5a105795f4514382a
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/n/nspr/libnspr4_4.35-1deepin1_amd64.deb
-    digest: 56f7b4a904b656643af51a360596c1428481d82c2d6a4f4db2a76455ad840a06
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/n/nss/libnss3_3.100-1_amd64.deb
-    digest: d353d50fc02254b83c72b488fea961cb4be9c371e60ab5ad04a0184e5aad88c5
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libn/libnumber-compare-perl/libnumber-compare-perl_0.03-2_all.deb
-    digest: c37a63d53d982b9596a8e498e9ef95cf07cc245eaa2a8df8fc8546e82511fa7c
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/p/p11-kit/libp11-kit0_0.24.0-5_amd64.deb
-    digest: 4e7b4eef76ec00eae267d45af8a98f5e7287fdb9dded5845f395a42f0d3c5b66
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/p/pango1.0/libpango-1.0-0_1.52.2+ds-1_amd64.deb
-    digest: 578da94d3d5cdecfa7206866fa668e3d34ab338366395dc4665501e61d1b7a23
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/p/pango1.0/libpangocairo-1.0-0_1.52.2+ds-1_amd64.deb
-    digest: 79abcf83edc6c1a9dc59f987374c9e980cf2ac8d99ef2cc5f0905b481ef7e113
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/p/pango1.0/libpangoft2-1.0-0_1.52.2+ds-1_amd64.deb
-    digest: 2102f48725fd401cf12395a26f261386483bb5516b280f8ab35e34da3df5b107
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libp/libpciaccess/libpciaccess0_0.16-1_amd64.deb
-    digest: 549736858b99dc151e23c249ff54a69d6c03c03784af6cf8af0b71094df33a69
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/p/pcre2/libpcre2-8-0_10.39-2_amd64.deb
-    digest: 26ba66e349a9d46978d24e5b165c327e1ef51007770c43a3a49eb35b5fe0310e
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/p/perl/libperl5.36_5.36.0-10_amd64.deb
-    digest: 1cca8c85872210489e92326ca7fda2fcc8d9b37a085cd1a0c87d54aa685118e8
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/p/pixman/libpixman-1-0_0.42.2-1_amd64.deb
-    digest: 61dfa0134fe4038b88e3e64081f7340277297771d3a7c1667277cb9b992d2d0a
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libp/libpng1.6/libpng16-16_1.6.40-2_amd64.deb
-    digest: 3327085ceef26f45c52af3462d6e506721371991a983b398e2fb741c2c48ab29
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/p/procps/libproc2-0_4.0.4-4_amd64.deb
-    digest: dcf36fc37d53d89d6fb80dd4d3094199f47cff8f4f622af050ff78ede2351fba
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libr/librsvg/librsvg2-2_2.54.7+dfsg-2deepin1_amd64.deb
-    digest: 5a83ad3b39da10c6025fb1c5deb826651b1824027e34879b4d707115f60a1013
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libr/librsvg/librsvg2-common_2.54.7+dfsg-2deepin1_amd64.deb
-    digest: 21accb2498d2301dad3f960a88443f5088c8b320594aca8dde7a80a4b08c9069
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libs/libselinux/libselinux1_3.5-1_amd64.deb
-    digest: 8f2c1b196a486e83ba8513e8ffe6bcceb5208fd0f5682173bbb8dca49033817e
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/l/lm-sensors/libsensors-config_3.6.0-7_all.deb
-    digest: 164115506dfd335f26101e76cb49e2162b0440398ccf2d0c969ebc465dfd7867
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/l/lm-sensors/libsensors5_3.6.0-7_amd64.deb
-    digest: 5a730040a0326f0124822fb9ffd632d4891c5451873049d630d0f9da63f0db10
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libw/libwebp/libsharpyuv0_1.3.2-0.2_amd64.deb
-    digest: 9da48196bd083c4749d1b4814a15780fdfa5a962ce3c19c5abfe0fa98e4e870e
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libs/libsm/libsm6_1.2.3-1_amd64.deb
-    digest: d8a6d0abf65a6fe4c5edcb5fa37b115477736e60c31118df74b701a468b49cab
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/s/snappy/libsnappy1v5_1.1.10-1_amd64.deb
-    digest: 5b062c9e447f90316be68c9e2750002dd33660b73cd501bf2c67280e4056b0f3
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/s/sqlite3/libsqlite3-0_3.45.1-1_amd64.deb
-    digest: 0f66c6b79083cdbe4f0c20db8dbd9d1b2b03064a324a4bcd454bd79cf7a41cf8
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/o/openssl/libssl3_3.2.0-2_amd64.deb
-    digest: df5390c0212f7bf86d51fc72a799d1bdd4be924babb0c10a5de4896664d6e5cc
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/g/gcc-13/libstdc++6_13.2.0-3deepin2_amd64.deb
-    digest: 8b8362c5c96e22487f2a3f96a41cd4ddb2d265bf8e991327f01b2c6c55f9a57b
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/s/systemd/libsystemd0_255.2-4_amd64.deb
-    digest: 66d48e2c47cf992897c35325e5aa0ad7a33a22d0ead358face789e3b82ab27c4
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libt/libtasn1-6/libtasn1-6_4.18.0-4_amd64.deb
-    digest: 3f24f7a181f374bd6623bfdc7781e2cee5d948361a456d2f6216aa4ba5c44a2e
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libt/libtext-glob-perl/libtext-glob-perl_0.11-2_all.deb
-    digest: 2e8cf563b486b56b4c875db16a37e5e24168085510b8bfd167efc8367cdcad1f
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libt/libthai/libthai-data_0.1.29-1_all.deb
-    digest: 3a87af58b0b3becac7062da11264d083cd68190e7dd421c2cbd00da8841cfa25
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libt/libthai/libthai0_0.1.29-1_amd64.deb
-    digest: f0bd45223660d1b5b5a0d8e34637cda429f1600a407c8f7970293cbb27c4e165
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/t/tiff/libtiff6_4.5.1+git230720-1_amd64.deb
-    digest: 8a0ee5ae052e11c5f52db3a793392cbcf8450760cc7ac83ff65d12b54120c83a
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/n/ncurses/libtinfo6_6.4-4_amd64.deb
-    digest: bb49775a3e3df73dbef25027937ddb2f714f262e8cb859ef228d26b3c146b6eb
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libu/libunistring/libunistring2_0.9.10-6_amd64.deb
-    digest: dfa507aa9982a3ba8cca86bc571d47e0c30d8adadc833e16cba4edd6e4c68155
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/u/util-linux/libuuid1_2.39.3-6deepin1_amd64.deb
-    digest: 8cc7e43d37649c4ee3595f33589716d7eea70ea4ccde666039b2b1d01a4f8413
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/v/vulkan-loader/libvulkan1_1.3.268.0-1_amd64.deb
-    digest: ea988ba1798a25fa13e1a6b852f1f8f8550293daead86a931846e4131a9e6c2e
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/w/wayland/libwayland-server0_1.22.0-1_amd64.deb
-    digest: 6c74185503a3795fd58faf093d2840539bcd607286cdf80379d5c99e9e912b16
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libw/libwebp/libwebp7_1.3.2-0.2_amd64.deb
-    digest: f2271cabfa4d4847bef8a522e2775d4f9c09a2560911df4779a7cc06d650eec6
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libx11/libx11-6_1.8.7-1_amd64.deb
-    digest: e21e2b12e455664dd8b6ceb201d853c120dea77e0703c95545a3176708ae699f
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libx11/libx11-data_1.8.7-1_all.deb
-    digest: 400aaa7eaab268850d8c2c512474228204d47774f2aac79cef29d1c125e0c656
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libx11/libx11-xcb1_1.8.7-1_amd64.deb
-    digest: 68341e587a81b03655ff00f0cc9ba543181285504475e66b422308b1bdd30e5f
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxau/libxau6_1.0.9-1_amd64.deb
-    digest: 0d55ab9b5634a7b635ebe263526719f3c5c925d847c0f4cb927bc61584cf269b
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxaw/libxaw7_1.0.13-1.1_amd64.deb
-    digest: 65d30fda1f56f2b1665c5e4b88ae908261784de9453b56167d47abbcb7ecded8
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxcb/libxcb-dri2-0_1.15-1_amd64.deb
-    digest: 691906c89f7d59cf4e8a244c333cd1e9a91b00241bd44e6d8f5b975905ac1a32
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxcb/libxcb-dri3-0_1.15-1_amd64.deb
-    digest: a55805048ef2bcbc16d6ed58879d173012291066e7e94f8ede8eb456d01c3079
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxcb/libxcb-glx0_1.15-1_amd64.deb
-    digest: b049c57d28e8785786edba1d9ff6139fb8e85f17dbeb921aa4437a160f28ecd9
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxcb/libxcb-present0_1.15-1_amd64.deb
-    digest: 548641b3568cf21f4359bed39375c1c8e873f92fa38955e310a27c3d0a0bd63c
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxcb/libxcb-randr0_1.15-1_amd64.deb
-    digest: 20d03b2822771bfeaf4ba3ae40faa96cf48e3a7c9bdf1d8ec37de6064a0ee02b
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxcb/libxcb-render0_1.15-1_amd64.deb
-    digest: ee032e334e48cdd15385fccde4b4baa399775d3a53aafa3a86e621012a47dae5
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxcb/libxcb-shape0_1.15-1_amd64.deb
-    digest: 135268523d9957b26d436eee5cbb699815e52d98077b4e99516a9078444c9fa9
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxcb/libxcb-shm0_1.15-1_amd64.deb
-    digest: 764d8a7b72cfcd3a4e3f1abb7b19c0af24e307a5595be04f06184b3817df8b44
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxcb/libxcb-sync1_1.15-1_amd64.deb
-    digest: 8e5d1b2a5e1bfca4c9408bc7b62c161359f4ef7c2f35a25ef1734fd857c08654
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxcb/libxcb-xfixes0_1.15-1_amd64.deb
-    digest: c32ee9a285da0ddb94ab374cece23c5403e691539b5d604a1450f5120485d18a
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxcb/libxcb1_1.15-1_amd64.deb
-    digest: 7472219060504d69f13cea545dde78da4b42455c3018f211d161315c7d8aa9f1
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxcomposite/libxcomposite1_0.4.5-1_amd64.deb
-    digest: d6d69b8ce6a61fdc97696e70b4609538b51d6ee05c83fcfc4d8016093341f3aa
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxcursor/libxcursor1_1.2.0-2_amd64.deb
-    digest: e30718a3a1cc7e6ee8c6b12c9afd9ae7b53c52ea71996cb9c6685b096bf11945
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxdamage/libxdamage1_1.1.5-2_amd64.deb
-    digest: 493c0ed32758cde152268d59cdddbf1ea4edccbda81b93a6263517698383b520
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_amd64.deb
-    digest: ebcc2294de7d5fb853478096435000c2c262f0cc27bb6e9cbd1455984e58a72f
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxext/libxext6_1.3.4-1_amd64.deb
-    digest: 59a91d747d250b40897b850d0aa7477a92aa671991287137875b1475a7708a85
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxfixes/libxfixes3_6.0.0-1_amd64.deb
-    digest: e4234708c3f3631d7f361a1429d8b9de9b8acc81244f23b8df64d599b62fcecd
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/x/xft/libxft2_2.3.2-2_amd64.deb
-    digest: dd69e8c6b1d30fefa8eb1e21456ce3c3c6492b3dc6bd0ec2e54ec637a76a2e77
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxi/libxi6_1.8-1_amd64.deb
-    digest: 7e0136391a631baec172eba189495a2afec63fef9e714dfb897e3a353e6ce014
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxinerama/libxinerama1_1.1.4-2_amd64.deb
-    digest: bcc37defa47aa2579f3e62fecb500d3f9d5a4285d403e97fabe4480ef7dc8ae8
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxkbcommon/libxkbcommon0_1.6.0-1_amd64.deb
+    url: https://community-packages.deepin.com/beige/pool/main/libx/libxkbcommon/libxkbcommon0_1.6.0-1_amd64.deb
     digest: c44ac854dbbe987c4a0ee11ddf526b8fff1b701edaa5d85b7495a81aeacc3686
+
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxkbfile/libxkbfile1_1.1.0-1_amd64.deb
-    digest: bf41e1fd2d5806c354321b247a3257b9dcf52d91f99a4e849029819abe5d60dc
+    url: https://community-packages.deepin.com/beige/pool/main/n/nspr/libnspr4_4.35-1deepin1_amd64.deb
+    digest: 56f7b4a904b656643af51a360596c1428481d82c2d6a4f4db2a76455ad840a06
+
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxml2/libxml2_2.9.14+dfsg-1.3+rb1_amd64.deb
-    digest: 62e17e37d376abed4c3e83c1ebd38d113fd32677a15dbf34d9fd7f0c49c48221
+    url: https://community-packages.deepin.com/beige/pool/main/c/cairo/libcairo2_1.18.0-1_amd64.deb
+    digest: cbf026997021678131d706318414a498b8054291185be3fa095fe8ea9fe162fc
+
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxmu/libxmu6_1.1.2-deepin1_amd64.deb
-    digest: d296c3849d13b1248ab7142bc825f303fbb7f137dacc0e81908d3eccf660c345
+    url: https://community-packages.deepin.com/beige/pool/main/a/alsa-lib/libasound2_1.2.12-1deepin1_amd64.deb
+    digest: 13c36d1ba89268f03f75be93ec321e393f377421f6867bfc22f243be102460b3
+
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxmu/libxmuu1_1.1.2-deepin1_amd64.deb
-    digest: 67df512feb6e5a3180a4214e59b2ec950572d2e9be635950f68d1c12feb50f91
+    url: https://community-packages.deepin.com/beige/pool/main/n/nss/libnss3_3.105-2_amd64.deb
+    digest: 2392052ca92a70fd7399dec7f7b20fb43baa4512328f76851a23a50f6ec36441
+
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxpm/libxpm4_3.5.12-1_amd64.deb
-    digest: d059120ee0223b38479b03c9693f9c4fe39fd71cb37d808185250311013b3aa9
+    url: https://community-packages.deepin.com/beige/pool/community/x/xdg-desktop-portal-wlr/xdg-desktop-portal-wlr_0.7.0-1_amd64.deb
+    digest: 0c7297f59642edb89583e6e2a5bf835cedf5122f5020fe79f4c203dc5082202a
+
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxrandr/libxrandr2_1.5.2-1_amd64.deb
+    url: https://community-packages.deepin.com/beige/pool/main/libx/libxdamage/libxdamage1_1.1.5-2_amd64.deb
+    digest: 493c0ed32758cde152268d59cdddbf1ea4edccbda81b93a6263517698383b520
+
+  - kind: file
+    url: https://community-packages.deepin.com/beige/pool/main/l/llvm-toolchain-16/libunwind-16_16.0.6-18deepin1+rb1_amd64.deb
+    digest: 23de7bcafa174044ea26f4c2e6cecaabf387149596d34c642614ff2f79907b8c
+
+  - kind: file
+    url: https://community-packages.deepin.com/beige/pool/main/f/freetype/libfreetype6_2.13.2+dfsg-1deepin1_amd64.deb
+    digest: 362fcb4c7c381338fd78bfa018b17b25f00596afb9c7d99c28b075944b20eb2b
+
+  - kind: file
+    url: https://community-packages.deepin.com/beige/pool/main/libx/libxcomposite/libxcomposite1_0.4.5-1_amd64.deb
+    digest: d6d69b8ce6a61fdc97696e70b4609538b51d6ee05c83fcfc4d8016093341f3aa
+
+  - kind: file
+    url: https://community-packages.deepin.com/beige/pool/main/libd/libdrm/libdrm2_2.4.123-1_amd64.deb
+    digest: c2f1676c3335ab76ff829190951052abef661b735f2ddfefdb8d6c0698c41756
+
+  - kind: file
+    url: https://community-packages.deepin.com/beige/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.1.5-2_amd64.deb
+    digest: 664abd1a931622f6d14cced9ea87f3b4f201adf9616e6ef2daf1b044903f699f
+
+  - kind: file
+    url: https://community-packages.deepin.com/beige/pool/main/g/glibc/libc6_2.38-6deepin7_amd64.deb
+    digest: d8928f5bfe6dfaa9b64ea2354c9d933c51805aa137e52d834efdd4a1b220f031
+
+  - kind: file
+    url: https://community-packages.deepin.com/beige/pool/main/h/harfbuzz/libharfbuzz0b_8.0.1-1+rb1_amd64.deb
+    digest: 29f8f51877821f22adc742cab010c0f627ff4db8ffb03a1479441c5f2061f9e3
+
+  - kind: file
+    url: https://community-packages.deepin.com/beige/pool/main/m/mesa/libgbm1_24.1.5-1deepin2_amd64.deb
+    digest: 48a32e67388800832f6a893ac7227ca6d21235f4f4394029d4adafb0e4db4f52
+
+  - kind: file
+    url: https://community-packages.deepin.com/beige/pool/main/e/expat/libexpat1_2.5.0-2_amd64.deb
+    digest: 5be8be254b82a58e77549b1784520f1f7ebb395b57982f87524533e1f061f75a
+
+  - kind: file
+    url: https://community-packages.deepin.com/beige/pool/main/libx/libxml2/libxml2_2.9.14+dfsg-1.3+rb2_amd64.deb
+    digest: 36b25f4121dd6765f49a5249a94f675139c4fbaae04be5ccc1ac3ae59f1e40c2
+
+  - kind: file
+    url: https://community-packages.deepin.com/beige/pool/main/a/at-spi2-core/libatk-bridge2.0-0_2.50.0-1_amd64.deb
+    digest: 251c33003337b63840a5eaa4e24bff47c179dedea3fc8b153e752ae2d4823484
+
+  - kind: file
+    url: https://community-packages.deepin.com/beige/pool/main/l/lcms2/liblcms2-2_2.14-2_amd64.deb
+    digest: a8630b7a9f07ca87612fdfe486941211598f4fe3148235746f001e68ce91114b
+
+  - kind: file
+    url: https://community-packages.deepin.com/beige/pool/main/libx/libxcb/libxcb1_1.15-1_amd64.deb
+    digest: 7472219060504d69f13cea545dde78da4b42455c3018f211d161315c7d8aa9f1
+
+  - kind: file
+    url: https://community-packages.deepin.com/beige/pool/main/l/llvm-toolchain-16/libc++abi1-16_16.0.6-18deepin1+rb1_amd64.deb
+    digest: f3b9ab98f5762dd351b7fa6590e2c9409da3d0902b714bc694198fa8832930fc
+
+  - kind: file
+    url: https://community-packages.deepin.com/beige/pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1deepin1_amd64.deb
+    digest: d0bab03ed3981fbe2bae8799a3c45d9a3b1561ae3d7bcffe37f235d573ae24c6
+
+  - kind: file
+    url: https://community-packages.deepin.com/beige/pool/main/l/llvm-toolchain-16/libc++1-16_16.0.6-18deepin1+rb1_amd64.deb
+    digest: ae8759bc2b3553638835a645e4bb83da964d2ea5e1b5b69f575460f5f8a31cc5
+
+  - kind: file
+    url: https://community-packages.deepin.com/beige/pool/main/h/harfbuzz/libharfbuzz-subset0_8.0.1-1+rb1_amd64.deb
+    digest: 0a3622ad0c88295ab34afcd78a20880b2f9dc52885aa1c44b020bb5c198b9cdc
+
+  - kind: file
+    url: https://community-packages.deepin.com/beige/pool/main/libx/libxslt/libxslt1.1_1.1.34-4_amd64.deb
+    digest: 57b60e3910615c73c78c090eb6f5a3d69c13638e2f212fe651a610e6b6d72ced
+
+  - kind: file
+    url: https://community-packages.deepin.com/beige/pool/main/a/at-spi2-core/libatk1.0-0_2.50.0-1_amd64.deb
+    digest: da6c703d5afc663d8d3716e3134b76bb47cecb54f75f0f6f846cbd47fd822613
+
+  - kind: file
+    url: https://community-packages.deepin.com/beige/pool/main/libp/libpng1.6/libpng16-16_1.6.40-2_amd64.deb
+    digest: 3327085ceef26f45c52af3462d6e506721371991a983b398e2fb741c2c48ab29
+
+  - kind: file
+    url: https://community-packages.deepin.com/beige/pool/main/g/gtk+3.0/libgtk-3-0_3.24.41-1deepin3_amd64.deb
+    digest: 881f5ae629072986d6f59b6b33ade6e9f8899cb988e45447af0120735d08c5ca
+
+  - kind: file
+    url: https://community-packages.deepin.com/beige/pool/main/libx/libxfixes/libxfixes3_6.0.0-1_amd64.deb
+    digest: e4234708c3f3631d7f361a1429d8b9de9b8acc81244f23b8df64d599b62fcecd
+
+  - kind: file
+    url: https://community-packages.deepin.com/beige/pool/main/libx/libxext/libxext6_1.3.4-1_amd64.deb
+    digest: 59a91d747d250b40897b850d0aa7477a92aa671991287137875b1475a7708a85
+
+  - kind: file
+    url: https://community-packages.deepin.com/beige/pool/main/g/glib2.0/libglib2.0-0_2.80.1-1deepin1_amd64.deb
+    digest: 33857078b63370d9edfbceec5a4f8d159db6f75da9f486dd12c97711598f43de
+
+  - kind: file
+    url: https://community-packages.deepin.com/beige/pool/main/libx/libxrandr/libxrandr2_1.5.2-1_amd64.deb
     digest: 99f09cd408f97768ac9bc9beca6af549a4c3b9dc91f5225bf3a0fab96410f833
+
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxrender/libxrender1_0.9.10-1_amd64.deb
-    digest: 3fe11eeffd33fee74287c85002204c97b9c624d84a79862e4ca5d37c7307253a
+    url: https://community-packages.deepin.com/beige/pool/main/p/pango1.0/libpango-1.0-0_1.52.2+ds-1_amd64.deb
+    digest: 578da94d3d5cdecfa7206866fa668e3d34ab338366395dc4665501e61d1b7a23
+
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxshmfence/libxshmfence1_1.3-1_amd64.deb
-    digest: d112a8a931b29eed0b2c058cc53f03be11dcf4fe2dc28a570c38cec52f687c92
+    url: https://community-packages.deepin.com/beige/pool/main/d/dbus/libdbus-1-3_1.14.10-3_amd64.deb
+    digest: 1dff3a63259f14e7de7c4502e7083f7077b30a274f09d195176d566406b1b827
+
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxt/libxt6_1.2.0-1_amd64.deb
-    digest: 265d9b8ddc3a22b7e7d2341941b01b763a5aa74b1c99e8b31b6541562bd2ddbb
+    url: https://community-packages.deepin.com/beige/pool/main/o/openjpeg2/libopenjp2-7_2.5.0-2_amd64.deb
+    digest: 1d7109a9c3f29c8bde7b4f92866d28860ee641dcfe3a718f4b730f845e63a4a4
+
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxtst/libxtst6_1.2.3-1_amd64.deb
-    digest: a434105d580d5958abdc4b0256968ffda0d06de7923250ec7518173e11271fbe
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxv/libxv1_1.0.11-1_amd64.deb
-    digest: 30a78145871e68591c84a2edbd4d817e4a0767dd14dbba0b6cfe904ead1a0ada
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxxf86dga/libxxf86dga1_1.1.4-deepin1_amd64.deb
-    digest: be08470a1ed419775cfaabe7e913c3df171f94682904a158504a367eaa6bb6da
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libx/libxxf86vm/libxxf86vm1_1.1.4-deepin1_amd64.deb
-    digest: 6ab24dd183238d561320ff6ab17df620297d4058d82e02606354740c0b8180f8
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/z/z3/libz3-4_4.8.12-deepin2_amd64.deb
-    digest: d3aae52f4765120827f28ad5a851da6f31ded2cb708397f2e5f8307dfc1f58da
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/libz/libzstd/libzstd1_1.5.5+dfsg2-2_amd64.deb
-    digest: 92fff5b68d38bc369552561614e82b841fc29587f1c2315842691493c52a5818
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/p/perl/perl_5.36.0-10_amd64.deb
-    digest: 59d13b610350339f3b273097011a3db6db60a99d587bf04eeb881c1a34168390
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/p/perl/perl-base_5.36.0-10_amd64.deb
-    digest: 50fa4a0bbefde86abf9ffd1fa092ee82af23ccc8f65b5b952526dc885c943169
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/p/perl/perl-modules-5.36_5.36.0-10_all.deb
-    digest: 907542b9a413bd0276d5ef94fef77083715a692fd33c52ece44d11fff847bab0
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/p/procps/procps_4.0.4-4_amd64.deb
-    digest: b1528a0323d4042b72f4646b89bc668d41a9f52cbac161f741e7097277766550
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/s/shared-mime-info/shared-mime-info_2.2-1_amd64.deb
-    digest: 545413a218d5cd7e3103b5e277419a7e67044c95f83ed7fb700c6c99ba523c02
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/t/tar/tar_1.35+dfsg-3_amd64.deb
-    digest: ee27ac0010bb1525067edda7b6b86110a00550232fb154f87491dbc3a3a2c8ff
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/u/usrmerge/usrmerge_38_all.deb
-    digest: fdc636985788b18a04cd15941a111fb2a73d3b56cf58c689b918345e6f003161
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/x/xorg/x11-common_7.7+23-deepin1_all.deb
-    digest: 9a7643db11023a8bec126312edec4b1b7357b93416bdfbaf9b0cb8bc04506d49
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/x/x11-utils/x11-utils_7.7+5-deepin_amd64.deb
-    digest: e2af6938565e0ec5c616c393ce38145a355a301286df73f3dccb97be4a3c8f18
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/x/xdg-utils/xdg-utils_1.1.3-4.1deepin1_all.deb
-    digest: d5e090896201fb8fa27fa3d42f2c56de7822c26b8b5f8d9c6c44da690f887c1a
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/x/xfonts-encodings/xfonts-encodings_1.0.4-2.1deepin1_all.deb
-    digest: 07d68c68eeeca62cea0558b4f0bc25896bd82fddfa6c4b02693ee0adc4bde224
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/x/xfonts-utils/xfonts-utils_7.7+6-deepin_amd64.deb
-    digest: 5a83d9ea46a19255d820eebcf8c6a8a08339e1e37ad11ac3b8d89d1dcb719e13
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/x/xkeyboard-config/xkb-data_2.38-2deepin1_all.deb
-    digest: 6fdc32f08737735128e20a10f9a8425bde19855e3917d8f26a62ea3a12a9a720
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/rc2/pool/main/z/zlib/zlib1g_1.3.dfsg-3_amd64.deb
-    digest: 96000bf9fabaf3da432e554ee8d1d07b54f35aa2ef825af714ccdba671e737fa
+    url: https://community-packages.deepin.com/beige/pool/main/libx/libx11/libx11-6_1.8.7-1_amd64.deb
+    digest: e21e2b12e455664dd8b6ceb201d853c120dea77e0703c95545a3176708ae699f
+


### PR DESCRIPTION
修复问题：

* [[【deepin 25】【集成测试】【浏览器】6.6.2.3版本浏览器，编辑PMS中BUG内容非常卡](https://pms.uniontech.com/bug-view-303847.html)
* [【deepin 25】【集成测试】【浏览器】系统切换到英文语言后，浏览器的启动页搜索引擎默认的是搜狗而不是Google](https://pms.uniontech.com/bug-view-303045.html)
* [【deepin 25】【集成测试】【浏览器】系统语言为英文时，浏览器的自定义设置界面缩略图应该展示成海外的网站图标，而非国内的一些网站图标](https://pms.uniontech.com/bug-view-303083.html)

增加功能：
* 主题切换（dark mode）